### PR TITLE
Tidy up home page tagline

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -145,7 +145,7 @@
 <div>
     <div>
         <content>                                        
-            <h3 class="banner-subtitle">official pass rates and faults on <span class="text-blue">MOT</span> testing</h3>                        
+            <h3 class="banner-subtitle">Pass rates and faults for <span class="text-blue">MOT</span> tests</h3>                        
         </content><!-- .banner-col-centered -->
     </div><!-- .banner-container -->                
 </div><!-- .banner-section -->


### PR DESCRIPTION
Start with capital; makes sentence read better.

Remove "official" because could be construed
as being an "official" DVSA app.
